### PR TITLE
Cambio de método donde se liberan reservas

### DIFF
--- a/stock_reserve_sale/model/sale.py
+++ b/stock_reserve_sale/model/sale.py
@@ -64,9 +64,9 @@ class SaleOrder(models.Model):
         return True
 
     @api.multi
-    def action_confirm(self):
+    def _action_confirm(self):
         self.release_all_stock_reservation()
-        return super(SaleOrder, self).action_confirm()
+        return super(SaleOrder, self)._action_confirm()
 
     @api.multi
     def action_cancel(self):


### PR DESCRIPTION
- [FIX] stock_reserve_sale: Liberar reservas en _action_confirm en vez de en action_confirm